### PR TITLE
feat: add time-based sequences for training

### DIFF
--- a/src/trainers.py
+++ b/src/trainers.py
@@ -99,7 +99,7 @@ class Trainer:
                 # 0. batch_data will be sent into the device(GPU or CPU)
                 batch = tuple(t.to(self.device) for t in batch)
 
-                user_ids, input_ids, answers, neg_answer, same_target = batch
+                user_ids, input_ids, time1_seq, time2_seq, answers, neg_answer, same_target = batch
                 loss = self.model.calculate_loss(input_ids, answers, neg_answer, same_target, user_ids)
                     
                 self.optim.zero_grad()
@@ -122,7 +122,7 @@ class Trainer:
 
             for i, batch in rec_data_iter:
                 batch = tuple(t.to(self.device) for t in batch)
-                user_ids, input_ids, answers, _, _ = batch
+                user_ids, input_ids, time1_seq, time2_seq, answers, _, _ = batch
                 recommend_output = self.model.predict(input_ids, user_ids)
                 recommend_output = recommend_output[:, -1, :]# 推荐的结果
                 


### PR DESCRIPTION
## Summary
- parse interaction timestamps into monthly and weekly indices
- return time indices alongside items in dataset and dataloader
- adjust trainer to handle extended batch structure

## Testing
- `python - <<'PY'
import sys
sys.path.append('src')
from utils import parse_args
from dataset import get_seq_dic, get_dataloder
args = parse_args()
args.data_dir = 'src/data/'
args.output_dir = 'src/output/'
args.data_name = 'Beauty'
args.max_seq_length = 5
args.batch_size = 2
args.num_workers = 0
args.model_type = 'bsarec'
args.no_cuda = True
seq_dic, max_item, num_users = get_seq_dic(args)
args.item_size = max_item + 1
train_loader, eval_loader, test_loader = get_dataloder(args, seq_dic)
batch = next(iter(train_loader))
print('batch length', len(batch))
for t in batch:
    print(t.shape)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b9b71177a48326a7e7f6e28e27d8f6