### PR TITLE
feat: support txt sequences in popularity generator

### DIFF
--- a/src/data/popularity/generate_popularity.py
+++ b/src/data/popularity/generate_popularity.py
@@ -5,11 +5,38 @@ from typing import Optional
 import numpy as np
 import pandas as pd
 
-def load_interactions(path: Path, sep: str):
-    """Load interactions with columns: user, item, rating, timestamp.
-    The file is expected to be delimiter-separated without header."""
-    df = pd.read_csv(path, sep=sep, engine="python", names=["user", "item", "rating", "timestamp"])
-    df = df[["item", "timestamp"]]
+
+def load_interactions(path: Path):
+    """Load interactions from a preprocessed txt file.
+
+    The file format of each line should be:
+
+        user item1:ts1 item2:ts2 ...
+
+    where ``user`` is ignored and each ``item:timestamp`` pair is
+    separated by whitespace.  Only item ids and their unix timestamps are
+    used to construct the DataFrame.
+    """
+
+    items = []
+    timestamps = []
+    with path.open() as f:
+        for line in f:
+            parts = line.strip().split()
+            if len(parts) <= 1:
+                continue
+            # skip the user id at index 0
+            for pair in parts[1:]:
+                if ":" not in pair:
+                    continue
+                item_str, ts_str = pair.split(":", 1)
+                try:
+                    items.append(int(item_str))
+                    timestamps.append(int(ts_str))
+                except ValueError:
+                    continue
+
+    df = pd.DataFrame({"item": items, "timestamp": timestamps})
     df["timestamp"] = pd.to_datetime(df["timestamp"], unit="s")
     return df
 
@@ -40,14 +67,19 @@ def aggregate_counts(
     return counts, period_map, item_map
 
 def main():
-    parser = argparse.ArgumentParser(description="Aggregate item popularity by month and week.")
-    parser.add_argument("input", type=Path, help="Path to raw interaction file")
-    parser.add_argument("--sep", default="::", help="Field separator in the input file")
-    parser.add_argument("--top_n", type=int, default=None, help="Keep only top N items by interaction count")
-    parser.add_argument("--out_dir", type=Path, default=Path(__file__).parent, help="Directory to save results")
+    parser = argparse.ArgumentParser(
+        description="Aggregate item popularity by month and week from preprocessed sequences."
+    )
+    parser.add_argument("input", type=Path, help="Path to txt file with user sequences")
+    parser.add_argument(
+        "--top_n", type=int, default=None, help="Keep only top N items by interaction count"
+    )
+    parser.add_argument(
+        "--out_dir", type=Path, default=Path(__file__).parent, help="Directory to save results"
+    )
     args = parser.parse_args()
 
-    df = load_interactions(args.input, args.sep)
+    df = load_interactions(args.input)
     # build initial item map using all items
     all_items = sorted(df["item"].unique())
     item_map = {item: idx + 1 for idx, item in enumerate(all_items)}


### PR DESCRIPTION
## Summary
- allow `generate_popularity.py` to read preprocessed `user item:timestamp` txt files
- expose cleaner CLI for generating month/week popularity tables

## Testing
- `pip install numpy pandas`
- `python src/data/popularity/generate_popularity.py sample.txt --out_dir tmp_pop`


------
https://chatgpt.com/codex/tasks/task_e_68bace1f9be08326ac735d230e8c7927