### PR TITLE
feat: support txt sequences in popularity generator

### DIFF
--- a/src/data/popularity/generate_popularity.py
+++ b/src/data/popularity/generate_popularity.py
@@ -5,11 +5,38 @@ from typing import Optional
 import numpy as np
 import pandas as pd
 
-def load_interactions(path: Path, sep: str):
-    """Load interactions with columns: user, item, rating, timestamp.
-    The file is expected to be delimiter-separated without header."""
-    df = pd.read_csv(path, sep=sep, engine="python", names=["user", "item", "rating", "timestamp"])
-    df = df[["item", "timestamp"]]
+
+def load_interactions(path: Path):
+    """Load interactions from a preprocessed txt file.
+
+    The file format of each line should be:
+
+        user item1:ts1 item2:ts2 ...
+
+    where ``user`` is ignored and each ``item:timestamp`` pair is
+    separated by whitespace.  Only item ids and their unix timestamps are
+    used to construct the DataFrame.
+    """
+
+    items = []
+    timestamps = []
+    with path.open() as f:
+        for line in f:
+            parts = line.strip().split()
+            if len(parts) <= 1:
+                continue
+            # skip the user id at index 0
+            for pair in parts[1:]:
+                if ":" not in pair:
+                    continue
+                item_str, ts_str = pair.split(":", 1)
+                try:
+                    items.append(int(item_str))
+                    timestamps.append(int(ts_str))
+                except ValueError:
+                    continue
+
+    df = pd.DataFrame({"item": items, "timestamp": timestamps})
     df["timestamp"] = pd.to_datetime(df["timestamp"], unit="s")
     return df
 
@@ -40,14 +67,24 @@ def aggregate_counts(
     return counts, period_map, item_map
 
 def main():
-    parser = argparse.ArgumentParser(description="Aggregate item popularity by month and week.")
-    parser.add_argument("input", type=Path, help="Path to raw interaction file")
-    parser.add_argument("--sep", default="::", help="Field separator in the input file")
-    parser.add_argument("--top_n", type=int, default=None, help="Keep only top N items by interaction count")
-    parser.add_argument("--out_dir", type=Path, default=Path(__file__).parent, help="Directory to save results")
+    parser = argparse.ArgumentParser(
+        description="Aggregate item popularity by month and week from preprocessed sequences."
+    )
+    parser.add_argument("input", type=Path, help="Path to txt file with user sequences")
+    parser.add_argument(
+        "--dataset",
+        required=True,
+        help="Dataset name prefix for output files",
+    )
+    parser.add_argument(
+        "--top_n", type=int, default=None, help="Keep only top N items by interaction count"
+    )
+    parser.add_argument(
+        "--out_dir", type=Path, default=Path(__file__).parent, help="Directory to save results"
+    )
     args = parser.parse_args()
 
-    df = load_interactions(args.input, args.sep)
+    df = load_interactions(args.input)
     # build initial item map using all items
     all_items = sorted(df["item"].unique())
     item_map = {item: idx + 1 for idx, item in enumerate(all_items)}
@@ -60,9 +97,15 @@ def main():
     week_eval[1] = week_counts[latest_week]
 
     args.out_dir.mkdir(parents=True, exist_ok=True)
-    np.savetxt(args.out_dir / "month_pop.txt", month_counts, fmt="%d")
-    np.savetxt(args.out_dir / "week_pop.txt", week_counts, fmt="%d")
-    np.savetxt(args.out_dir / "week_eval_pop.txt", week_eval, fmt="%d")
+    np.savetxt(
+        args.out_dir / f"{args.dataset}_month_pop.txt", month_counts, fmt="%d"
+    )
+    np.savetxt(
+        args.out_dir / f"{args.dataset}_week_pop.txt", week_counts, fmt="%d"
+    )
+    np.savetxt(
+        args.out_dir / f"{args.dataset}_week_eval_pop.txt", week_eval, fmt="%d"
+    )
 
 if __name__ == "__main__":
     main()

--- a/src/model/bsarec.py
+++ b/src/model/bsarec.py
@@ -20,6 +20,7 @@ class BSARecModel(SequentialRecModel):
                 args.base_dim1,
                 args.base_dim2,
                 args.popularity_dir,
+                args.data_name,
             )
             self.pop_embed = nn.Linear(
                 args.input_units1 + args.input_units2, args.hidden_size
@@ -31,6 +32,7 @@ class BSARecModel(SequentialRecModel):
                     args.base_dim1,
                     args.base_dim2,
                     args.popularity_dir,
+                    args.data_name,
                     enable_eval=True,
                     pause=args.pause,
                 )

--- a/src/model/popularity.py
+++ b/src/model/popularity.py
@@ -16,6 +16,7 @@ class PopularityEncoding(torch.nn.Module):
         base_dim1: int,
         base_dim2: int,
         popularity_dir,
+        dataset: str,
     ):
         super().__init__()
         self.input1 = input_units1
@@ -24,8 +25,8 @@ class PopularityEncoding(torch.nn.Module):
         self.base_dim2 = base_dim2
 
         pop_dir = Path(popularity_dir)
-        month_pop = np.loadtxt(pop_dir / "month_pop.txt")
-        week_pop = np.loadtxt(pop_dir / "week_pop.txt")
+        month_pop = np.loadtxt(pop_dir / f"{dataset}_month_pop.txt")
+        week_pop = np.loadtxt(pop_dir / f"{dataset}_week_pop.txt")
 
         self.register_buffer(
             "month_pop_table",
@@ -109,6 +110,7 @@ class EvalPopularityEncoding(torch.nn.Module):
         base_dim1: int,
         base_dim2: int,
         popularity_dir,
+        dataset: str,
         pause: bool = False,
     ):
         super().__init__()
@@ -119,9 +121,9 @@ class EvalPopularityEncoding(torch.nn.Module):
         self.pause = pause
 
         pop_dir = Path(popularity_dir)
-        month_pop = np.loadtxt(pop_dir / "month_pop.txt")
-        week_pop = np.loadtxt(pop_dir / "week_pop.txt")
-        week_eval_pop = np.loadtxt(pop_dir / "week_eval_pop.txt")
+        month_pop = np.loadtxt(pop_dir / f"{dataset}_month_pop.txt")
+        week_pop = np.loadtxt(pop_dir / f"{dataset}_week_pop.txt")
+        week_eval_pop = np.loadtxt(pop_dir / f"{dataset}_week_eval_pop.txt")
 
         self.register_buffer("week_eval_pop", torch.FloatTensor(week_eval_pop))
         self.register_buffer(
@@ -218,6 +220,7 @@ def build_popularity_encoding(
     base_dim1: int,
     base_dim2: int,
     popularity_dir,
+    dataset: str,
     enable_eval: bool = False,
     pause: bool = False,
 ):
@@ -239,9 +242,10 @@ def build_popularity_encoding(
             base_dim1,
             base_dim2,
             popularity_dir,
+            dataset,
             pause=pause,
         )
     return PopularityEncoding(
-        input_units1, input_units2, base_dim1, base_dim2, popularity_dir
+        input_units1, input_units2, base_dim1, base_dim2, popularity_dir, dataset
     )
 


### PR DESCRIPTION
## Summary
- allow `generate_popularity.py` to read preprocessed `user item:timestamp` txt files
- namespace popularity tables with dataset-specific prefixes and load matching files in the model

## Testing
- `pip install numpy pandas`
- `python src/data/popularity/generate_popularity.py sample.txt --dataset toy --out_dir tmp_pop`
- `ls tmp_pop`
- `PYTHONPATH=src python - <<'PY'
from model.popularity import build_popularity_encoding
enc = build_popularity_encoding(1,1,1,1,'tmp_pop','toy')
PY` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch --index-url https://download.pytorch.org/whl/cpu` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_68bace1f9be08326ac735d230e8c7927