### PR TITLE
Fix popularity handling and evaluation logic in BSARec

### DIFF
--- a/src/trainers.py
+++ b/src/trainers.py
@@ -86,10 +86,6 @@ class Trainer:
 
         str_code = "train" if train else "test"
 
-        if (not train and getattr(self.args, "use_week_eval", False)
-                and hasattr(self.model, "eval_popularity_enc")):
-            self.model.popularity_enc = self.model.eval_popularity_enc
-
         # Setting the tqdm progress bar
         rec_data_iter = tqdm.tqdm(enumerate(dataloader),
                                   desc="Mode_%s:%d" % (str_code, epoch),


### PR DESCRIPTION
## Summary
- correctly initialize popularity encoders and switch to eval version automatically
- ensure popularity encoding uses proper device tensors and raises IndexError instead of pausing
- simplify trainer iteration by removing manual encoder swapping

## Testing
- `python -m py_compile src/model/bsarec.py src/model/popularity.py src/trainers.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68bbe70670d48326bcccb1c81e6705ae