### PR TITLE
feat: allow optional test leakage

### DIFF
--- a/src/dataset.py
+++ b/src/dataset.py
@@ -20,8 +20,30 @@ class RecDataset(Dataset):
 
         if self.data_type=='train':
             for user, seq in enumerate(user_seq):
-                input_ids = seq[-(self.max_len + 2):-2]
-                input_times = time_seq[user][-(self.max_len + 2):-2]
+                """
+                By default the original implementation excludes the last two
+                interactions of each user (validation and test items) from the
+                training data. To intentionally leak a portion of the test data
+                into the training set we allow including the last interaction
+                for a random subset of users controlled by
+                ``args.test_train_ratio``.
+
+                When ``test_train_ratio`` > 0 and the current user is selected,
+                we keep the entire sequence (including the test item) for
+                training. Otherwise we follow the original behaviour and remove
+                the last two items.
+                """
+
+                if getattr(args, 'test_train_ratio', 0) > 0 \
+                        and random.random() < args.test_train_ratio:
+                    # Include the test item in the training sequence
+                    input_ids = seq[-(self.max_len + 1):]
+                    input_times = time_seq[user][-(self.max_len + 1):]
+                else:
+                    # Original behaviour: exclude validation and test items
+                    input_ids = seq[-(self.max_len + 2):-2]
+                    input_times = time_seq[user][-(self.max_len + 2):-2]
+
                 for i in range(len(input_ids)):
                     self.user_seq.append(input_ids[:i + 1])
                     self.time_seq.append(input_times[:i + 1])

--- a/src/utils.py
+++ b/src/utils.py
@@ -70,6 +70,12 @@ def parse_args():
     parser.add_argument("--log_freq", default=1, type=int, help="per epoch print res")
     parser.add_argument("--patience", default=10, type=int, help="how long to wait after last time validation loss improved")
     parser.add_argument("--num_workers", default=4, type=int)
+    parser.add_argument(
+        "--test_train_ratio",
+        default=0.0,
+        type=float,
+        help="fraction of users whose test interaction is leaked into training",
+    )
 
     parser.add_argument("--seed", default=42, type=int)
     parser.add_argument("--weight_decay", default=0.0, type=float, help="weight_decay of adam")


### PR DESCRIPTION
## Summary
- add `test_train_ratio` arg to optionally leak part of the test interactions into training
- include selected test items when building training dataset

## Testing
- `python -m py_compile src/dataset.py src/utils.py`
- `python - <<'PY'
import sys, types
sys.modules['torch']=types.ModuleType('torch')
sys.path.append('src')
from utils import parse_args
sys.argv=['main','--help']
try:
    parse_args()
except SystemExit:
    pass
PY`

------
https://chatgpt.com/codex/tasks/task_e_68bd6028f9a08326bf803e6eb3f3f9e7